### PR TITLE
Automatic docfx github page generation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         cd src
         dotnet restore
-    - name: docfx
+    - name: generate docfx site
       run: |
         dotnet tool install -g docfx
         docfx init -y
@@ -32,3 +32,14 @@ jobs:
         cp README.md index.md
         docfx docfx.json
         ls -alh _site
+    - name: push site to gh-pages
+      run: |
+          git config --global user.name 'Miha Zidar'
+          git config --global user.email 'm.zidar@sportradar.com'
+          git checkout -B gh-pages
+          mv _site .git/
+          rm -rf *
+          mv .git/_site/* .
+          git add .
+          git commit -am "Automated github page generation"
+          git push origin gh-pages -f

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,34 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: |
+        cd src
+        dotnet restore
+    - name: docfx
+      run: |
+        dotnet tool install -g docfx
+        docfx init -y
+        git checkout docfx.json
+        cp README.md index.md
+        docfx docfx.json
+        ls -alh _site

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,45 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "./src",
+          "files": [
+            "**/*.csproj"
+          ]
+        }
+      ],
+      "dest": "api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "_site/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ]
+      }
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "Mbs SDK",
+      "_appTitle": "Mbs SDK",
+      "_enableSearch": true,
+      "pdf": false
+    }
+  }
+}


### PR DESCRIPTION
# description
This pr will automatically generate a new documentation site and push it to gh-pages branch on every merge to main.

Resulting workflows can be seen here:
main workflow: https://github.com/zidarsk8/MbsSdkNet/actions/runs/8097257052
and gh-pages workflow: https://github.com/zidarsk8/MbsSdkNet/actions/runs/8097268129

and the resulting documentation site should look like:
https://zidarsk8.github.io/MbsSdkNet